### PR TITLE
Split Reporting from Build

### DIFF
--- a/.github/workflows/coverage-build.yaml
+++ b/.github/workflows/coverage-build.yaml
@@ -1,16 +1,12 @@
-name: Check Coverage
+name: Build Coverage
 
 on:
   pull_request:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  coverage:
+  coverage-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,8 +21,9 @@ jobs:
         run: |
           coverage run -m pytest
           coverage xml
-      - name: Get Cover
-        uses: orgoro/coverage@v3.1
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v4
         with:
-            coverageFile: coverage.xml
-            token: ${{ secrets.GITHUB_TOKEN }}
+          name: coverage.xml
+          path: coverage.xml
+          retention-days: 1

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,0 +1,27 @@
+name: Report Coverage
+
+on:
+  workflow_run:
+    workflows: ["Build Coverage"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage-report:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage.xml
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Cover
+        uses: orgoro/coverage@v3
+        with:
+            coverageFile: coverage.xml
+            token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Coverage will not run from a fork, for very reasonable security concerns as to comment on a PR requires a token and permissions. Which would enable a malicious actor to acquire all sorts of repository details. Using on workflow_run mitigates this