### PR TITLE
Fix testing under Windows

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,9 @@ from unittest import TestCase, mock
 from cally.cdk import CallyStack
 
 
+from .constants import HOME_ENVS
+
+
 class CallyTestHarness(TestCase):
     working: TemporaryDirectory
 
@@ -16,7 +19,7 @@ class CallyTestHarness(TestCase):
         self.env_patcher = mock.patch.dict(
             os.environ,
             {
-                "HOME": self.working.name,
+                HOME_ENVS.get(os.name, 'UNKNOWN'): self.working.name,
                 "LC_ALL": os.environ.get('LC_ALL', 'C.UTF-8'),
                 "LANG": os.environ.get('LANG', 'C.UTF-8'),
             },

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,4 @@
+HOME_ENVS = {
+    'posix': 'HOME',
+    'nt': 'USERPROFILE',
+}


### PR DESCRIPTION
There were a couple of small issues that caused the test harness to fail under windows.

- TemporaryDirectory cleanup failed silently on linux, loudly on windows
- Windows uses a different env var for the home directory.