### PR TITLE
Configurable Backend

### DIFF
--- a/src/cally/cli/config/types.py
+++ b/src/cally/cli/config/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Optional
 
 
@@ -9,13 +9,42 @@ class CallyService:
 
 
 @dataclass
+class CallyBackend:
+    config: dict = field(default_factory=dict)
+    type: str = 'LocalBackend'
+    path: str = 'state/{environment}/{name}'
+    path_key: str = 'path'
+
+    def backend_config(self, service: dict) -> dict:
+        return {self.path_key: self.path.format(**service), **self.config}
+
+
+@dataclass
 class CallyStackService(CallyService):
     stack_type: str
+    backend: CallyBackend = field(default_factory=CallyBackend)
     providers: dict = field(default_factory=dict)
     stack_vars: dict = field(default_factory=dict)
+
+    def __setattr__(self, prop, val):
+        if prop == 'backend' and isinstance(val, dict):
+            super().__setattr__(prop, CallyBackend(**val))
+            return
+        super().__setattr__(prop, val)
+
+    @property
+    def backend_type(self) -> str:
+        return self.backend.type
+
+    @property
+    def backend_config(self) -> dict:
+        return self.backend.backend_config(self.to_dict())
 
     def get_provider_vars(self, provider: str) -> dict:
         return self.providers.get(provider, {})
 
     def get_stack_var(self, var: str, default: Optional[Any] = None) -> Any:
         return self.stack_vars.get(var, default)
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/src/cally/cli/config/validators.py
+++ b/src/cally/cli/config/validators.py
@@ -32,4 +32,7 @@ BASE_CALLY_CONFIG = [
         is_type_of=dict,
         messages=OPERATIONS_MESSAGE,
     ),
+    Validator("BACKEND.type", is_type_of=str, messages=OPERATIONS_MESSAGE),
+    Validator("BACKEND.path", is_type_of=str, messages=OPERATIONS_MESSAGE),
+    Validator("BACKEND.key", is_type_of=str, messages=OPERATIONS_MESSAGE),
 ]

--- a/tests/cli/config/test_types.py
+++ b/tests/cli/config/test_types.py
@@ -49,3 +49,41 @@ class TestCallyStackService(CallyTestHarness):
             name='snoopy', environment='yard', stack_type='CallyStack'
         )
         self.assertEqual(service.get_stack_var('test', 'charlie'), 'charlie')
+
+    def test_default_backend(self):
+        service = CallyStackService(
+            name='snoopy', environment='yard', stack_type='CallyStack'
+        )
+        self.assertEqual(service.backend_type, 'LocalBackend')
+
+    def test_default_state_path(self):
+        service = CallyStackService(
+            name='snoopy', environment='yard', stack_type='CallyStack'
+        )
+        self.assertDictEqual(service.backend_config, {'path': 'state/yard/snoopy'})
+
+    def test_supplied_backend(self):
+        service = CallyStackService(
+            name='snoopy',
+            environment='yard',
+            stack_type='CallyStack',
+            backend={'type': 'GcsBackend'},
+        )
+        self.assertEqual(service.backend_type, 'GcsBackend')
+
+    def test_custom_path(self):
+        service = CallyStackService(
+            name='snoopy',
+            environment='yard',
+            stack_type='CallyStack',
+            providers={'google': {'project': 'test-project'}},
+            backend={
+                'path': '{environment}/{providers[google][project]}/{name}',
+                'path_key': 'prefix',
+                'config': {'bucket': 'BucketyMcBucketFace'},
+            },
+        )
+        self.assertDictEqual(
+            service.backend_config,
+            {'bucket': 'BucketyMcBucketFace', 'prefix': 'yard/test-project/snoopy'},
+        )

--- a/tests/cli/test_tf.py
+++ b/tests/cli/test_tf.py
@@ -20,7 +20,7 @@ class TfTests(CallyTestHarness):
             obj=CallyConfig(config_file='blah.yaml'),
         )
         self.assertEqual(result.exit_code, 0)
-        testdata = {"backend": {"local": {"path": "state/test.tfstate"}}}
+        testdata = {"backend": {"local": {"path": "state/test/test"}}}
         self.assertDictEqual(
             json.loads(result.output).get('terraform'),
             testdata,

--- a/tests/stacks/test_cally.py
+++ b/tests/stacks/test_cally.py
@@ -11,3 +11,17 @@ class CallyStackTests(CallyTfTestHarness):
         self.assertDictEqual(
             result.get('terraform'), self.load_json_file('cdk/empty_synth.json')
         )
+
+    def test_gcs_backend(self):
+        service = self.empty_service
+        service.backend = {
+            'type': 'GcsBackend',
+            'path_key': 'prefix',
+            'path': 'water/{environment}/{name}',
+            'config': {'bucket': 'BucketyMcBucketFace'},
+        }
+        stack = CallyStack(service=service)
+        result = self.synth_stack(stack)
+        self.assertDictEqual(
+            result.get('terraform'), self.load_json_file('cdk/gcs_backend.json')
+        )

--- a/tests/testdata/cdk/empty_synth.json
+++ b/tests/testdata/cdk/empty_synth.json
@@ -1,7 +1,7 @@
 {
     "backend": {
         "local": {
-            "path": "state/test.tfstate"
+            "path": "state/cally/test"
         }
     }
 }

--- a/tests/testdata/cdk/gcs_backend.json
+++ b/tests/testdata/cdk/gcs_backend.json
@@ -1,0 +1,8 @@
+{
+    "backend": {
+        "gcs": {
+            "bucket": "BucketyMcBucketFace",
+            "prefix": "water/cally/test"
+        }
+    }
+}

--- a/tests/testdata/cli/empty_print.json
+++ b/tests/testdata/cli/empty_print.json
@@ -11,7 +11,7 @@
     "terraform": {
       "backend": {
         "local": {
-          "path": "state/test-cli.tfstate"
+          "path": "state/cally/test"
         }
       }
     }


### PR DESCRIPTION
This allows the Terraform backend to be configured anywhere the 'backend' is specified in the cally config