### PR TITLE
Fix Data Refs

### DIFF
--- a/src/cally/cdk/__init__.py
+++ b/src/cally/cdk/__init__.py
@@ -2,7 +2,8 @@ import inspect
 from copy import deepcopy
 from dataclasses import dataclass, field, make_dataclass
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from cdktf import (
     App,
@@ -60,7 +61,7 @@ class CallyResource:
     attributes: CallyResourceAttributes
     provider: str
     resource: str
-    defaults: dict
+    defaults: Union[dict, MappingProxyType]
 
     def __init__(self, identifier: Optional[str] = None, **kwargs) -> None:
         module = import_module(f'cally.providers.{self.provider}.{self.resource}')

--- a/src/cally/cdk/__init__.py
+++ b/src/cally/cdk/__init__.py
@@ -70,7 +70,7 @@ class CallyResource:
 
     def __str__(self) -> str:
         if self.tf_identifier:
-            return f'${{{self.resource}.{self.tf_identifier}.id}}'
+            return f'${{{self.tf_resource}.{self.tf_identifier}.id}}'
         return self.__class__.__name__
 
     def __getattr__(self, item: str) -> Optional[str]:
@@ -80,7 +80,7 @@ class CallyResource:
         if item in {'attributes', 'defaults', '_instantiated_resource'}:
             return None
         if self.tf_identifier:
-            return f'${{{self.resource}.{self.tf_identifier}.{item}}}'
+            return f'${{{self.tf_resource}.{self.tf_identifier}.{item}}}'
         return None
 
     def _get_attribute_default(self, name: str) -> Any:
@@ -112,6 +112,12 @@ class CallyResource:
     @property
     def tf_identifier(self) -> Optional[str]:
         return self._tf_identifier
+
+    @property
+    def tf_resource(self) -> Optional[str]:
+        if self.resource.startswith('data_'):
+            return f'data.{self.resource[5:]}'
+        return self.resource
 
     def construct_resource(
         self,

--- a/tests/stacks/test_resources.py
+++ b/tests/stacks/test_resources.py
@@ -113,3 +113,14 @@ class CallyResourceTests(CallyTfTestHarness):
                 }
             ],
         )
+
+    def test_data_resource_reference(self):
+        class DataGoogleStorageBucket(CallyResource):
+            provider = 'google'
+            resource = 'data_google_storage_bucket'
+            defaults = MappingProxyType({'location': 'AUSTRALIA-SOUTHEAST1'})
+
+        self.assertEqual(
+            str(DataGoogleStorageBucket('bucketo', name='fish')),
+            '${data.google_storage_bucket.bucketo.id}',
+        )

--- a/tests/stacks/test_resources.py
+++ b/tests/stacks/test_resources.py
@@ -24,10 +24,8 @@ class CallyResourceTests(CallyTfTestHarness):
             resource = 'storage_bucket'
             defaults = MappingProxyType({'location': 'AUSTRALIA-SOUTHEAST1'})
 
-        bucket_chips = StorageBucket(identifier='bucket', name='chips')
-        bucket_fish = StorageBucket(
-            identifier='bucketo', name='fish', depends_on=[bucket_chips]
-        )
+        bucket_chips = StorageBucket('bucket', name='chips')
+        bucket_fish = StorageBucket('bucketo', name='fish', depends_on=[bucket_chips])
         stack.add_resources([bucket_chips, bucket_fish])
         result = self.synth_stack(stack)
         self.assertEqual(
@@ -52,9 +50,7 @@ class CallyResourceTests(CallyTfTestHarness):
             defaults = MappingProxyType({'location': 'AUSTRALIA-SOUTHEAST1'})
 
         stack.add_resource(
-            StorageBucket(
-                identifier='bucketo', name='fish', versioning=StorageBucketVersioning()
-            )
+            StorageBucket('bucketo', name='fish', versioning=StorageBucketVersioning())
         )
         result = self.synth_stack(stack)
         self.assertDictEqual(
@@ -91,7 +87,7 @@ class CallyResourceTests(CallyTfTestHarness):
 
         stack.add_resource(
             StorageBucket(
-                identifier='bucketo',
+                'bucketo',
                 name='fish',
                 lifecycle_rule=[
                     StorageBucketLifecycleRule(


### PR DESCRIPTION
Data refs require stripping `data_` from the resource name, and returning it as `data.provider_resource_name`.

## Extra
- At some point `identifier` being an attribute on our resource wrapper was going to bring us unstuck. Renamed to `tf_identifier`
- `MappingProxyType` is the recommended way to provide a class level dictionary, allowing this to avoid type complaints