### PR TITLE
Missing token for gh cli

### DIFF
--- a/.github/workflows/build-tool-cache.yaml
+++ b/.github/workflows/build-tool-cache.yaml
@@ -51,3 +51,5 @@ jobs:
 
       - name: Upload asset
         run: gh release upload v${{ inputs.version }} ${TOOL_CACHE_PATH,,}.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This exports the token for the gh cli, which is required for uploading of assets