### PR TITLE
fix: Checkout for cli

### DIFF
--- a/.github/workflows/build-tool-cache.yaml
+++ b/.github/workflows/build-tool-cache.yaml
@@ -18,6 +18,7 @@ jobs:
           - "3.11"
           - "3.12"
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
gh cli uses implied details from the .git file, adding the checkout so that these can be used for upload