### PR TITLE
fix: Write Terraform

### DIFF
--- a/src/cally/cli/commands/tf.py
+++ b/src/cally/cli/commands/tf.py
@@ -18,7 +18,7 @@ def print_template(config: CallyStackServiceConfig):
         click.secho(action.print())
 
 
-@click.command(name='write')
+@click.command(name='write', cls=CallyStackServiceCommand())
 @click.option(
     '--output',
     type=click.Path(path_type=Path),

--- a/tests/cli/test_tf.py
+++ b/tests/cli/test_tf.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
@@ -21,5 +22,27 @@ class TfTests(CallyTestHarness):
         testdata = {"backend": {"local": {"path": "state/test/test"}}}
         self.assertDictEqual(
             json.loads(result.output).get('terraform'),
+            testdata,
+        )
+
+    @mock.patch.dict(os.environ, {"CALLY_STACK_TYPE": "CallyStack"})
+    def test_empty_write(self):
+        data = Path(self.working.name, 'cdk.tf.json')
+        result = CliRunner().invoke(
+            tf,
+            [
+                'write',
+                '--service',
+                'test',
+                '--environment',
+                'test',
+                '--output',
+                data.as_posix(),
+            ],
+        )
+        self.assertEqual(result.exit_code, 0)
+        testdata = {"backend": {"local": {"path": "state/test/test"}}}
+        self.assertDictEqual(
+            json.loads(data.read_text(encoding='utf8')).get('terraform'),
             testdata,
         )


### PR DESCRIPTION
During the refactor, a class for the write command was missed. Fixed the command and added a test to ensure it won't be missed in future changes