### PR TITLE
ci: Add uv action

### DIFF
--- a/.github/workflows/coverage-build.yaml
+++ b/.github/workflows/coverage-build.yaml
@@ -11,6 +11,8 @@ jobs:
   coverage-build:
     runs-on: ubuntu-latest
     needs: build-providers
+    env:
+      UV_SYSTEM_PYTHON: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v3
@@ -23,15 +25,16 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      - uses: yezz123/setup-uv@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
       - name: Export Terraform Path
         run: echo "CALLY_TERRAFORM_PATH=$(which terraform)" >> $GITHUB_ENV
       - name: Install Provider Pacakges
-        run: pip install build/**/*.tar.gz
+        run: uv pip install build/**/*.tar.gz
       - name: Install Cally test dependencies
-        run: pip install .[test]
+        run: uv pip install .[test]
       - name: Run Coverage
         run: |
           coverage run -m pytest

--- a/.github/workflows/test-cally.yaml
+++ b/.github/workflows/test-cally.yaml
@@ -15,6 +15,8 @@ jobs:
     strategy:
       matrix:
         python: ["3.11"]
+    env:
+      UV_SYSTEM_PYTHON: true
     steps:
       # Restore Provider Packages
       - uses: actions/checkout@v4
@@ -30,10 +32,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
+      - uses: yezz123/setup-uv@v4
       - name: Install Provider Pacakges
-        run: pip install build/**/*.tar.gz
+        run: uv pip install build/**/*.tar.gz
       - name: Install Cally test dependencies
-        run: pip install .[test]
+        run: uv pip install .[test]
 
       # Run Tests
       - name: Run Pytest

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         project: ["minimal", "opinionated"]
+    env:
+      UV_SYSTEM_PYTHON: true
     steps:
       # Restore Provider Packages
       - uses: actions/checkout@v4
@@ -29,10 +31,11 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      - uses: yezz123/setup-uv@v4
       - name: Install Provider Pacakges
-        run: pip install build/**/*.tar.gz
+        run: uv pip install build/**/*.tar.gz
       - name: Install Cally
-        run: pip install .
+        run: uv pip install .
 
       # IDP Install
       - uses: actions/checkout@v4
@@ -41,7 +44,7 @@ jobs:
           path: examples
       - name: Install ${{ matrix.project }}
         working-directory: examples/${{ matrix.project }}
-        run: pip install .[test]
+        run: uv pip install .[test]
 
       # Run Tests
       - name: Run Pytest for ${{ matrix.project }}


### PR DESCRIPTION
A good chunk of time is spent installing packages. UV is blisteringly fast in this regard.

- Without uv: ~30s for package installation
- With uv: ~7s for package installation

Given the uv action only takes 2 seconds, that's a worthwhile improvement.