### PR TITLE
fix: Terraform Passthrough

### DIFF
--- a/src/cally/cli/commands/tf.py
+++ b/src/cally/cli/commands/tf.py
@@ -46,18 +46,35 @@ def write_template(config: CallyStackServiceConfig, output: Path):
     default='/usr/bin/terraform',
     help='Path to the terraform binary',
 )
+@click.option(
+    '--terraform-cache',
+    envvar='CALLY_TERRAFORM_CACHE',
+    type=click.Path(path_type=Path),
+    default=Path(Path.home().as_posix(), '.cache', 'cally'),
+    help='Path to the services\' terraform plan/provider cache',
+)
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
 def run_terraform(
-    config: CallyStackServiceConfig, terraform_path: str, args: Tuple[str, ...]
+    config: CallyStackServiceConfig,
+    terraform_path: str,
+    terraform_cache: Path,
+    args: Tuple[str, ...],
 ):
-    tf_cmd = terraform.Command(terraform_path=terraform_path, arguments=args)
-    with terraform.Action(service=config.config) as action:
-        action.synth_stack()
+    terraform_cache.mkdir(exist_ok=True)
+    with terraform.Command(
+        service=config.config,
+        terraform_path=terraform_path,
+        terraform_cache=terraform_cache,
+        arguments=args,
+    ) as tf_cmd:
+        with terraform.Action(service=config.config) as action:
+            action.synth_stack()
+            Path('cdk.tf.json').write_text(action.print(), encoding='utf-8')
         if not tf_cmd.success:
             click.secho(message=tf_cmd.stderr, fg='red')
             sys.exit(tf_cmd.returncode)
-    click.secho(tf_cmd.stdout)
+        click.secho(tf_cmd.stdout)
 
 
 tf.add_command(print_template)


### PR DESCRIPTION
The intent was that each service would be able to init in its own path, so that no clashing would occur when trying to init/plan/apply each service when operating outside of CI/CD. The passthrough feature missed that step.

This puts the cdk.tf.json into a cache path and runs the terraform command within that path