### PR TITLE
Fix config examples

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ CDK
 Config
 ------
 
-.. autoclass:: cally.cli.config.types.CallyStackService
+.. autoclass:: cally.cli.config.config_types.CallyStackService
     :members:
 
 .. autofunction:: cally.cli.config.service_options

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,7 +21,7 @@ Config
 .. autoclass:: cally.cli.config.config_types.CallyStackService
     :members:
 
-.. autofunction:: cally.cli.config.service_options
+.. autofunction:: cally.cli.config.service.CallyServiceCommand
 
 
 Testing

--- a/docs/cdk.rst
+++ b/docs/cdk.rst
@@ -149,7 +149,7 @@ stacks
     :caption: stacks/gcp.py
 
     from cally.cdk import CallyStack
-    from cally.cli.config.types import CallyStackService
+    from cally.cli.config.config_types import CallyStackService
     from ..resources import storage
 
 

--- a/src/cally/cli/config/service.py
+++ b/src/cally/cli/config/service.py
@@ -24,6 +24,20 @@ class CallyServiceConfigContext(click.Context):
 
 
 def CallyServiceCommand():  # noqa: N802
+    """This can be applied to the 'cls' kwarg of a click.command decorator. It
+    will make all service options available to the decorated command. Best combined
+    with the pass object decorator for convenient access to the CallyServiceConfig
+    object.
+
+    Example usage::
+
+        @click.command(name='print', cls=CallyServiceCommand())
+        @click.pass_obj
+        def example(service: CallyServiceConfig):
+            click.echo(service.config.name)
+
+    """
+
     class CallyServiceCommandClass(CallyCommandClass):
         context_class = CallyServiceConfigContext
         default_cally_options = CALLY_SERVICE_OPTIONS


### PR DESCRIPTION
Fixes config examples for CallyServiceCommand, and updates the config_types reference.