### PR TITLE
ci: Deploy Pages on Release

### DIFF
--- a/.github/workflows/release-cally.yaml
+++ b/.github/workflows/release-cally.yaml
@@ -94,3 +94,12 @@ jobs:
     uses: ./.github/workflows/build-tool-cache.yaml
     with:
       version: ${{ needs.build-artifact.outputs.version }}
+
+  trigger-pages-deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - build-artifact
+      - generate-pypi-release
+    steps:
+      - name: Trigger Pages Deployment
+        run: curl -s -X POST "${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}" > /dev/null 2>&1


### PR DESCRIPTION
We were deploying using the automatic mechanisms from cloudflare, this switches to a deploy hook to ensure the docs match the released version.